### PR TITLE
Part of the code is obsolete

### DIFF
--- a/lectures/09-exceptions-and-with.slim
+++ b/lectures/09-exceptions-and-with.slim
@@ -302,10 +302,11 @@
 
     example:
         from contextlib import closing
-        import codecs
+        from urllib.request import urlopen
 
-        with closing(urllib.urlopen('http://www.python.org')) as page:
+        with closing(urlopen('http://www.python.org')) as page:
             for line in page:
                 print(line)
+
 
 


### PR DESCRIPTION
Кода в лекцията е валиден за Python2. В Python3 функциите в библиотеката са разделени на urllib.request и urllib.error.
