### PR TITLE
Change variable name for location in function example

### DIFF
--- a/lectures/01-introduction-to-python.slim
+++ b/lectures/01-introduction-to-python.slim
@@ -337,8 +337,8 @@
 
 = slide 'Функции' do
     example:
-       def say_hello(name, from):
-           return "Hello, {}! -- {}".format(name, from)
+       def say_hello(name, from_who):
+           return "Hello, {}! -- {}".format(name, from_who)
     list:
         Функцията приема аргументи
         Функцията може да върне нещо с `return`, иначе автоматично се връща `None`


### PR DESCRIPTION
from е запазена дума от python езика и се използва при import на пакети (https://docs.python.org/2/tutorial/modules.html#intra-package-references) и по този начин дефинирана `def say_hello(name, from):` не работи. Затова промених името на втория аргумент да е from_who вместо form